### PR TITLE
To add promcode files to conneg.yml

### DIFF
--- a/config/conneg.yml
+++ b/config/conneg.yml
@@ -130,14 +130,14 @@ ns_definitions:
 
    - prefix: "/ns/promcode"
     core_version: "3.0"
-    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs02/promcode-vocab.html"
+    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs03/promcode-vocab.html"
     files:
       rdfxml: "promcode/promcode-vocab.rdf"
       ntriples: "promcode/promcode-vocab.nt"
       jsonld: "promcode/promcode-vocab.jsonld"
       turtle: "promcpromcode/promcode-shapes.ttl"
     core_version: "3.0"
-    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs02/promcode-shapes.html"
+    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs03/promcode-shapes.html"
     files:
       rdfxml: "promcode/promcode-shapes.rdf"
       ntriples: "promcode/promcode-shapes.nt"

--- a/config/conneg.yml
+++ b/config/conneg.yml
@@ -128,6 +128,22 @@ ns_definitions:
       jsonld: "trs/trs-shapes.jsonld"
       turtle: "trs/trs-shapes.ttl"
 
+   - prefix: "/ns/promcode"
+    core_version: "3.0"
+    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs02/promcode-vocab.html"
+    files:
+      rdfxml: "promcode/promcode-vocab.rdf"
+      ntriples: "promcode/promcode-vocab.nt"
+      jsonld: "promcode/promcode-vocab.jsonld"
+      turtle: "promcpromcode/promcode-shapes.ttl"
+    core_version: "3.0"
+    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs02/promcode-shapes.html"
+    files:
+      rdfxml: "promcode/promcode-shapes.rdf"
+      ntriples: "promcode/promcode-shapes.nt"
+      jsonld: "promcode/promcode-shapes.jsonld"
+      turtle: "promcode/promcode-shapes.ttl"
+      
   - prefix: "/ns/asset"
     core_version: "2.0"
     html_uri: "https://archive.open-services.net/wiki/asset-management/OSLC-Asset-Management-Vocabulary/index.html"

--- a/config/conneg.yml
+++ b/config/conneg.yml
@@ -130,14 +130,14 @@ ns_definitions:
 
    - prefix: "/ns/promcode"
     core_version: "3.0"
-    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs03/promcode-vocab.html"
+    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/os/promcode-vocab.html"
     files:
       rdfxml: "promcode/promcode-vocab.rdf"
       ntriples: "promcode/promcode-vocab.nt"
       jsonld: "promcode/promcode-vocab.jsonld"
       turtle: "promcpromcode/promcode-shapes.ttl"
     core_version: "3.0"
-    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs03/promcode-shapes.html"
+    html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/os/promcode-shapes.html"
     files:
       rdfxml: "promcode/promcode-shapes.rdf"
       ntriples: "promcode/promcode-shapes.nt"

--- a/config/conneg.yml
+++ b/config/conneg.yml
@@ -128,14 +128,16 @@ ns_definitions:
       jsonld: "trs/trs-shapes.jsonld"
       turtle: "trs/trs-shapes.ttl"
 
-   - prefix: "/ns/promcode"
+  - prefix: "/ns/promcode"
     core_version: "3.0"
     html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/os/promcode-vocab.html"
     files:
       rdfxml: "promcode/promcode-vocab.rdf"
       ntriples: "promcode/promcode-vocab.nt"
       jsonld: "promcode/promcode-vocab.jsonld"
-      turtle: "promcpromcode/promcode-shapes.ttl"
+      turtle: "promcode/promcode-shapes.ttl"
+   
+  - prefix: "/ns/promcode/shapes/1.0"
     core_version: "3.0"
     html_uri: "https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/os/promcode-shapes.html"
     files:

--- a/test.sh
+++ b/test.sh
@@ -42,6 +42,7 @@ test_ns "ns/am"
 test_ns "ns/asset"
 test_ns "ns/auto"
 test_ns "ns/perfmon"
-# test_ns "ns/ems"
+test_ns "ns/promcode"
+test_ns "ns/promcode/shapes/1.0"
 
 echo "${green}ALL TESTS PASSED${reset}"


### PR DESCRIPTION
Since promode files are not in oslc-op/website yet, I put url of shapes.html and vocab.html at https://docs.oasis-open.org/oslc-promcode/promcode/v1.0/cs02/. 